### PR TITLE
Fix Marp preview connection refused on WSL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: neovim/setup-neovim@v2
+        with:
+          version: stable
+
+      - name: Cache plenary.nvim
+        uses: actions/cache@v4
+        with:
+          path: .deps/plenary.nvim
+          key: plenary-${{ runner.os }}-${{ hashFiles('scripts/minimal_init.lua') }}
+          restore-keys: |
+            plenary-${{ runner.os }}-
+
+      - name: Run specs
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: neovim/setup-neovim@v2
+      - uses: rhysd/action-setup-vim@v1
         with:
+          neovim: true
           version: stable
 
       - name: Cache plenary.nvim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ luac.out
 deps/node_modules/
 deps/package-lock.json
 
+# Test dependencies
+.deps/
+

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ luac.out
 *.x86_64
 *.hex
 
+# Bundled Marp CLI dependencies
+deps/node_modules/
+deps/package-lock.json
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test
+
+NVIM ?= nvim
+MINIMAL_INIT := scripts/minimal_init.lua
+
+test:
+	$(NVIM) --headless \
+		-u $(MINIMAL_INIT) \
+		-c "lua require('plenary.test_harness').test_directory('spec', { minimal_init = '$(MINIMAL_INIT)' })" \
+		-c "qa"

--- a/README.md
+++ b/README.md
@@ -77,23 +77,6 @@ With lazy.nvim `opts` (no separate `config` function needed):
   },
 ```
 
-Local development with lazy.nvim:
-
-```lua
-  {
-    dir = "/path/to/marp-nvim",
-    name = "marp-nvim",
-    ft = "markdown",
-    cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
-    opts = {
-      close_browser_on_stop = true,
-    },
-    build = function(plugin)
-      require("marp").install(plugin.dir)
-    end,
-  },
-```
-
 The plugin also registers a `FileType` autocmd for `markdown`, so it loads when you open a Markdown file even without lazy-loading configuration. With lazy.nvim, `ft = "markdown"` is still recommended so the plugin is not loaded at startup.
 
 If Marp CLI is not found on your `PATH` and is not yet installed in the plugin, `:MarpInstall` is registered automatically so you can install it manually.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ A [neovim](https://neovim.io/) plugin for [Marp](https://marp.app/).
 - see if Marp server is running
 - browser window opens when Marp is running and ready
 - automatically installs Marp CLI into the plugin when needed
+- optionally close the browser preview tab when stopping the server
 
 ## ⚡️ Requirements
 
-- [Node.js](https://nodejs.org/) v18+ and `npm` (for automatic Marp CLI installation)
+- [Node.js](https://nodejs.org/) v18+ and `npm` (for automatic Marp CLI installation and the preview wrapper)
 - Alternatively, install [Marp CLI](https://marp.app/) globally and the plugin will use it from your `PATH`
 
 ## 📦 Installation
@@ -20,7 +21,7 @@ Install the plugin with your preferred package manager:
 Packer:
 ```lua
   use({
-    "mpas/marp-nvim",
+    "alexesba/marp-nvim",
     ft = "markdown",
     run = function()
       require("marp").install()
@@ -31,7 +32,7 @@ Packer:
 Lazy (recommended — loads on Markdown buffers, installs Marp CLI on plugin install/update):
 ```lua
   {
-    "mpas/marp-nvim",
+    "alexesba/marp-nvim",
     ft = "markdown",
     cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
     build = function(plugin)
@@ -44,7 +45,7 @@ Lazy (recommended — loads on Markdown buffers, installs Marp CLI on plugin ins
 With a specific configuration:
 ```lua
   {
-    "mpas/marp-nvim",
+    "alexesba/marp-nvim",
     ft = "markdown",
     cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
     build = function(plugin)
@@ -55,6 +56,7 @@ With a specific configuration:
         port = 8080,
         wait_for_response_timeout = 30,
         wait_for_response_delay = 1,
+        close_browser_on_stop = true,
       })
     end,
   },
@@ -77,14 +79,21 @@ The following defaults are provided:
   auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
   use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
   marp_version = "latest", -- npx package version when falling back to npx
-  close_browser_on_stop = false, -- experimental: close preview tab on :MarpStop
+  close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
 }
 ```
 
-### Experimental: close browser tab on stop
+Marp CLI resolution order when `marp_command` is not set:
 
-On branch `feature/browser-close-wrapper`, you can enable a small preview wrapper that opens Marp inside a controlled page and listens for a close signal when you run `:MarpStop` (similar in spirit to `markdown-preview.nvim`).
+1. `marp` on your `PATH`
+2. Bundled install in the plugin's `deps/` directory
+3. Auto-install into `deps/` if `auto_install` is true
+4. `npx @marp-team/marp-cli@<marp_version>` if `use_npx_fallback` is true
+
+### Close browser tab on stop
+
+Set `close_browser_on_stop = true` to close the preview tab when you run `:MarpStop`.
 
 ```lua
 require("marp").setup({
@@ -95,20 +104,11 @@ require("marp").setup({
 How it works:
 
 1. Marp still runs on `port` (default `8080`)
-2. A tiny Node wrapper serves `http://127.0.0.1:<port+1>/` with an iframe to Marp
+2. A small Node wrapper serves `http://127.0.0.1:<port+1>/` with an iframe to Marp
 3. The wrapper page uses Server-Sent Events (SSE) to receive a `close` event
 4. `:MarpStop` POSTs to `/close`, which tells the page to call `window.close()`
 
-**Caveats:** `window.close()` is not guaranteed in every browser — some only allow it for script-opened windows. If the tab stays open, it will show a connection error after the server stops. Requires Node.js (already needed for bundled Marp CLI install).
-
-Marp CLI resolution order when `marp_command` is not set:
-
-1. `marp` on your `PATH`
-2. Bundled install in the plugin's `deps/` directory
-3. Auto-install into `deps/` if `auto_install` is true
-4. `npx @marp-team/marp-cli@<marp_version>` if `use_npx_fallback` is true
-
-In the above example, the Marp server will be started on port 8080, and the plugin will wait for up to 30 seconds for a response from the server before giving up. It will try to connect to the server every second.
+**Note:** `window.close()` is not guaranteed in every browser. If the tab stays open, it will show a connection error after the server stops.
 
 ## ⌨️ Keybindings
 This plugin does not set any keybindings by default. You can set them yourself like this:
@@ -131,4 +131,4 @@ Marp CLI can recognize custom themes that are in the `themes/` directory in your
 
 ## 💡Inspiration
 
-This plugin is inspired by [aca/marp.nvim](https://github.com/aca/marp.nvim)!
+This plugin is inspired by [aca/marp.nvim](https://github.com/aca/marp.nvim) and [mpas/marp-nvim](https://github.com/mpas/marp-nvim)!

--- a/README.md
+++ b/README.md
@@ -21,19 +21,23 @@ Packer:
 ```lua
   use({
     "mpas/marp-nvim",
+    ft = "markdown",
     run = function()
       require("marp").install()
     end,
   }),
 ```
 
-Lazy (recommended — installs Marp CLI on plugin install/update):
+Lazy (recommended — loads on Markdown buffers, installs Marp CLI on plugin install/update):
 ```lua
   {
     "mpas/marp-nvim",
+    ft = "markdown",
+    cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
     build = function(plugin)
       require("marp").install(plugin.dir)
     end,
+    config = true,
   },
 ```
 
@@ -41,6 +45,8 @@ With a specific configuration:
 ```lua
   {
     "mpas/marp-nvim",
+    ft = "markdown",
+    cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
     build = function(plugin)
       require("marp").install(plugin.dir)
     end,
@@ -54,7 +60,9 @@ With a specific configuration:
   },
 ```
 
-You can also install the bundled Marp CLI manually at any time with `:MarpInstall`.
+The plugin also registers a `FileType` autocmd for `markdown`, so it loads when you open a Markdown file even without lazy-loading configuration. With lazy.nvim, `ft = "markdown"` is still recommended so the plugin is not loaded at startup.
+
+If Marp CLI is not found on your `PATH` and is not yet installed in the plugin, `:MarpInstall` is registered automatically so you can install it manually.
 
 ## ⚙️ Configuration
 
@@ -95,7 +103,7 @@ The following commands are available:
 - `:MarpStop` - stop the Marp server
 - `:MarpToggle` - toggle the Marp server (start/stop)
 - `:MarpStatus` - see if Marp server is running
-- `:MarpInstall` - install the bundled Marp CLI into the plugin
+- `:MarpInstall` - install the bundled Marp CLI (only registered when Marp is not already available)
 
 ## 🎨 Theming
 Marp CLI can recognize custom themes that are in the `themes/` directory in your project's root directory. For example, if you open neovim in the `presentations` directory, created a directory inside of `presentations` called `themes` and place the theme CSS files inside of this directory. They should be automatically loaded by Marp and applied to presentations with the theme specified.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The following defaults are provided:
   marp_version = "latest", -- npx package version when falling back to npx
   close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
+  server_dir = nil, -- directory passed to marp --server; nil uses resolve_server_dir()
+  use_buffer_dir = true, -- serve the current Markdown buffer's directory instead of cwd
 }
 ```
 
@@ -122,6 +124,19 @@ Marp CLI resolution order when `marp_command` is not set:
 2. Bundled install in the plugin's `deps/` directory
 3. Auto-install into `deps/` if `auto_install` is true
 4. `npx @marp-team/marp-cli@<marp_version>` if `use_npx_fallback` is true
+
+### Server directory in large projects
+
+By default, `:MarpStart` runs `marp --server` on the **current Markdown buffer's directory**, not Neovim's working directory. This avoids serving an entire repository (for example a Rails app root with `node_modules/`, `tmp/`, and thousands of files).
+
+Override when needed:
+
+```lua
+require("marp").setup({
+  server_dir = "/path/to/slides", -- always serve this directory
+  use_buffer_dir = false,         -- use vim.fn.getcwd() instead of the buffer path
+})
+```
 
 ### Close browser tab on stop
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [neovim](https://neovim.io/) plugin for [Marp](https://marp.app/).
 - see if Marp server is running
 - browser window opens when Marp is running and ready
 - automatically installs Marp CLI into the plugin when needed
-- optionally close the browser preview tab when stopping the server
+- optionally close the browser preview tab when stopping the server (`close_browser_on_stop`)
 
 ## ⚡️ Requirements
 
@@ -56,8 +56,40 @@ With a specific configuration:
         port = 8080,
         wait_for_response_timeout = 30,
         wait_for_response_delay = 1,
-        close_browser_on_stop = true,
       })
+    end,
+  },
+```
+
+With lazy.nvim `opts` (no separate `config` function needed):
+
+```lua
+  {
+    "alexesba/marp-nvim",
+    ft = "markdown",
+    cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
+    opts = {
+      close_browser_on_stop = true,
+    },
+    build = function(plugin)
+      require("marp").install(plugin.dir)
+    end,
+  },
+```
+
+Local development with lazy.nvim:
+
+```lua
+  {
+    dir = "/path/to/marp-nvim",
+    name = "marp-nvim",
+    ft = "markdown",
+    cmd = { "MarpStart", "MarpStop", "MarpToggle", "MarpStatus" },
+    opts = {
+      close_browser_on_stop = true,
+    },
+    build = function(plugin)
+      require("marp").install(plugin.dir)
     end,
   },
 ```
@@ -93,7 +125,7 @@ Marp CLI resolution order when `marp_command` is not set:
 
 ### Close browser tab on stop
 
-Set `close_browser_on_stop = true` to close the preview tab when you run `:MarpStop`.
+Disabled by default. Set `close_browser_on_stop = true` to open Marp through a small wrapper page so `:MarpStop` can signal the browser to close the tab.
 
 ```lua
 require("marp").setup({

--- a/README.md
+++ b/README.md
@@ -77,8 +77,29 @@ The following defaults are provided:
   auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
   use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
   marp_version = "latest", -- npx package version when falling back to npx
+  close_browser_on_stop = false, -- experimental: close preview tab on :MarpStop
+  wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
 }
 ```
+
+### Experimental: close browser tab on stop
+
+On branch `feature/browser-close-wrapper`, you can enable a small preview wrapper that opens Marp inside a controlled page and listens for a close signal when you run `:MarpStop` (similar in spirit to `markdown-preview.nvim`).
+
+```lua
+require("marp").setup({
+  close_browser_on_stop = true,
+})
+```
+
+How it works:
+
+1. Marp still runs on `port` (default `8080`)
+2. A tiny Node wrapper serves `http://127.0.0.1:<port+1>/` with an iframe to Marp
+3. The wrapper page uses Server-Sent Events (SSE) to receive a `close` event
+4. `:MarpStop` POSTs to `/close`, which tells the page to call `window.close()`
+
+**Caveats:** `window.close()` is not guaranteed in every browser — some only allow it for script-opened windows. If the tab stays open, it will show a connection error after the server stops. Requires Node.js (already needed for bundled Marp CLI install).
 
 Marp CLI resolution order when `marp_command` is not set:
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ A [neovim](https://neovim.io/) plugin for [Marp](https://marp.app/).
 - toggle the Marp server (start/stop)
 - see if Marp server is running
 - browser window opens when Marp is running and ready
+- automatically installs Marp CLI into the plugin when needed
 
 ## ⚡️ Requirements
 
-- [Marp](https://marp.app/) CLI installed and available in your path
+- [Node.js](https://nodejs.org/) v18+ and `npm` (for automatic Marp CLI installation)
+- Alternatively, install [Marp CLI](https://marp.app/) globally and the plugin will use it from your `PATH`
+
 ## 📦 Installation
 
 Install the plugin with your preferred package manager:
@@ -18,13 +21,19 @@ Packer:
 ```lua
   use({
     "mpas/marp-nvim",
+    run = function()
+      require("marp").install()
+    end,
   }),
 ```
 
-Lazy:
+Lazy (recommended — installs Marp CLI on plugin install/update):
 ```lua
   {
     "mpas/marp-nvim",
+    build = function(plugin)
+      require("marp").install(plugin.dir)
+    end,
   },
 ```
 
@@ -32,6 +41,9 @@ With a specific configuration:
 ```lua
   {
     "mpas/marp-nvim",
+    build = function(plugin)
+      require("marp").install(plugin.dir)
+    end,
     config = function()
       require("marp").setup({
         port = 8080,
@@ -42,6 +54,7 @@ With a specific configuration:
   },
 ```
 
+You can also install the bundled Marp CLI manually at any time with `:MarpInstall`.
 
 ## ⚙️ Configuration
 
@@ -52,8 +65,19 @@ The following defaults are provided:
   port = 8080, -- the port on which the Marp server should listen
   wait_for_response_timeout = 30, -- how long to wait for a response from the server before giving up
   wait_for_response_delay = 1, -- how long to wait between attempts to connect to the server
+  marp_command = nil, -- override Marp executable; nil auto-resolves PATH, bundled, then npx
+  auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
+  use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
+  marp_version = "latest", -- npx package version when falling back to npx
 }
 ```
+
+Marp CLI resolution order when `marp_command` is not set:
+
+1. `marp` on your `PATH`
+2. Bundled install in the plugin's `deps/` directory
+3. Auto-install into `deps/` if `auto_install` is true
+4. `npx @marp-team/marp-cli@<marp_version>` if `use_npx_fallback` is true
 
 In the above example, the Marp server will be started on port 8080, and the plugin will wait for up to 30 seconds for a response from the server before giving up. It will try to connect to the server every second.
 
@@ -71,6 +95,7 @@ The following commands are available:
 - `:MarpStop` - stop the Marp server
 - `:MarpToggle` - toggle the Marp server (start/stop)
 - `:MarpStatus` - see if Marp server is running
+- `:MarpInstall` - install the bundled Marp CLI into the plugin
 
 ## 🎨 Theming
 Marp CLI can recognize custom themes that are in the `themes/` directory in your project's root directory. For example, if you open neovim in the `presentations` directory, created a directory inside of `presentations` called `themes` and place the theme CSS files inside of this directory. They should be automatically loaded by Marp and applied to presentations with the theme specified.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following defaults are provided:
   marp_version = "latest", -- npx package version when falling back to npx
   close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
+  preview_host = nil, -- browser preview hostname; nil auto-detects (WSL uses the VM IP)
   server_dir = nil, -- directory passed to marp --server; nil uses resolve_server_dir()
   use_buffer_dir = true, -- serve the current Markdown buffer's directory instead of cwd
 }
@@ -139,6 +140,24 @@ How it works:
 4. `:MarpStop` POSTs to `/close`, which tells the page to call `window.close()`
 
 **Note:** `window.close()` is not guaranteed in every browser. If the tab stays open, it will show a connection error after the server stops.
+
+### WSL (Windows)
+
+Neovim in WSL opens the preview in your **Windows** browser (via `wslview`). The preview wrapper listens on `127.0.0.1` by default, which Windows cannot reach.
+
+On WSL the plugin automatically:
+
+1. Binds the preview wrapper to `0.0.0.0`
+2. Opens the browser using the WSL VM IP (from `hostname -I`)
+3. Points the wrapper iframe at the same host so Marp loads correctly
+
+If auto-detection fails, set the host manually:
+
+```lua
+require("marp").setup({
+  preview_host = "172.21.17.252", -- output of: hostname -I | awk '{print $1}'
+})
+```
 
 ## ⌨️ Keybindings
 This plugin does not set any keybindings by default. You can set them yourself like this:

--- a/deps/package.json
+++ b/deps/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "marp-nvim-deps",
+  "private": true,
+  "dependencies": {
+    "@marp-team/marp-cli": "^4.4.0"
+  }
+}

--- a/lua/marp-nvim/init.lua
+++ b/lua/marp-nvim/init.lua
@@ -1,0 +1,1 @@
+return require("marp")

--- a/lua/marp/cli.lua
+++ b/lua/marp/cli.lua
@@ -1,0 +1,68 @@
+local config = require("marp.config")
+local install = require("marp.install")
+local util = require("marp.util")
+
+local M = {}
+
+local function npx_argv(version)
+  return { "npx", "@marp-team/marp-cli@" .. version }
+end
+
+---@return string[]|nil argv Prefix argv for `marp --server <dir>` (without --server or directory).
+---@return string|nil err
+function M.resolve_argv()
+  local opts = config.options
+
+  if opts.marp_command then
+    if opts.marp_command:match("%s") then
+      return vim.split(opts.marp_command, "%s+"), nil
+    end
+    return { opts.marp_command }, nil
+  end
+
+  if vim.fn.executable("marp") == 1 then
+    return { "marp" }, nil
+  end
+
+  local bundled = install.bundled_path()
+  if bundled then
+    return { bundled }, nil
+  end
+
+  if opts.auto_install then
+    local ok, err = install.sync()
+    if ok then
+      bundled = install.bundled_path()
+      if bundled then
+        return { bundled }, nil
+      end
+    elseif err then
+      util.log_warn(err)
+    end
+  end
+
+  if opts.use_npx_fallback then
+    if vim.fn.executable("npx") ~= 1 then
+      return nil, "Marp CLI not found; install Node.js v18+ or set marp_command"
+    end
+    local version = opts.marp_version or "latest"
+    return npx_argv(version), nil
+  end
+
+  return nil, "Marp CLI not found; run :MarpInstall or set marp_command"
+end
+
+---@return string[]|nil argv Full argv for starting the Marp server.
+---@return table|nil env Environment variables for jobstart.
+---@return string|nil err
+function M.server_argv(port, cwd)
+  local prefix, err = M.resolve_argv()
+  if not prefix then
+    return nil, nil, err
+  end
+
+  local argv = vim.list_extend(vim.deepcopy(prefix), { "--server", cwd })
+  return argv, { PORT = tostring(port) }, nil
+end
+
+return M

--- a/lua/marp/cli.lua
+++ b/lua/marp/cli.lua
@@ -4,6 +4,29 @@ local util = require("marp.util")
 
 local M = {}
 
+--- Whether a Marp executable is available without npx or auto-install.
+function M.has_executable()
+  local opts = config.options
+
+  if opts.marp_command and opts.marp_command ~= "" then
+    return true
+  end
+
+  if vim.fn.executable("marp") == 1 then
+    return true
+  end
+
+  if install.bundled_path() then
+    return true
+  end
+
+  return false
+end
+
+function M.needs_install()
+  return not M.has_executable()
+end
+
 local function npx_argv(version)
   return { "npx", "@marp-team/marp-cli@" .. version }
 end

--- a/lua/marp/config.lua
+++ b/lua/marp/config.lua
@@ -10,6 +10,8 @@ local defaults = {
   marp_version = "latest", -- npx package version when falling back to npx
   close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
+  server_dir = nil, -- directory passed to marp --server; nil uses resolve_server_dir()
+  use_buffer_dir = true, -- serve the current Markdown buffer's directory instead of cwd
 }
 
 M.options = {}

--- a/lua/marp/config.lua
+++ b/lua/marp/config.lua
@@ -8,6 +8,8 @@ local defaults = {
   auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
   use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
   marp_version = "latest", -- npx package version when falling back to npx
+  close_browser_on_stop = false, -- experimental: wrap preview to close browser tab on :MarpStop
+  wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
 }
 
 M.options = {}

--- a/lua/marp/config.lua
+++ b/lua/marp/config.lua
@@ -4,6 +4,10 @@ local defaults = {
   port = 8080, -- the port on which the Marp server should listen
   wait_for_response_timeout = 30, -- how long to wait for a response from the server before giving up
   wait_for_response_delay = 1, -- how long to wait between attempts to connect to the server
+  marp_command = nil, -- override Marp executable; nil auto-resolves PATH, bundled, then npx
+  auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
+  use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
+  marp_version = "latest", -- npx package version when falling back to npx
 }
 
 M.options = {}

--- a/lua/marp/config.lua
+++ b/lua/marp/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   marp_version = "latest", -- npx package version when falling back to npx
   close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
+  preview_host = nil, -- browser preview hostname; nil auto-detects (WSL uses the VM IP)
   server_dir = nil, -- directory passed to marp --server; nil uses resolve_server_dir()
   use_buffer_dir = true, -- serve the current Markdown buffer's directory instead of cwd
 }

--- a/lua/marp/config.lua
+++ b/lua/marp/config.lua
@@ -8,7 +8,7 @@ local defaults = {
   auto_install = true, -- install @marp-team/marp-cli into plugin deps when missing
   use_npx_fallback = true, -- use npx when marp is not on PATH and bundled install is unavailable
   marp_version = "latest", -- npx package version when falling back to npx
-  close_browser_on_stop = false, -- experimental: wrap preview to close browser tab on :MarpStop
+  close_browser_on_stop = false, -- close preview tab on :MarpStop via preview wrapper
   wrapper_port = nil, -- preview wrapper port; defaults to marp port + 1
 }
 

--- a/lua/marp/init.lua
+++ b/lua/marp/init.lua
@@ -1,3 +1,4 @@
+local cli = require("marp.cli")
 local config = require("marp/config")
 local install = require("marp.install")
 local marp = require("marp/marp")
@@ -11,18 +12,35 @@ M.status = marp.status
 M.toggle = marp.toggle
 M.install = install.sync
 
--- create MarpStart command
-vim.api.nvim_create_user_command("MarpStart", M.start, { desc = "Start Marp" })
-vim.api.nvim_create_user_command("MarpStop", M.stop, { desc = "Stop Marp" })
-vim.api.nvim_create_user_command("MarpStatus", M.status, { desc = "Show Marp status" })
-vim.api.nvim_create_user_command("MarpToggle", M.toggle, { desc = "Toggle Marp (start/stop)" })
-vim.api.nvim_create_user_command("MarpInstall", function(opts)
-  local ok, err = install.sync(opts.args ~= "" and opts.args or nil)
-  if ok then
-    vim.notify("Marp CLI is installed", vim.log.levels.INFO)
-  else
-    vim.notify("Marp install failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
+local function register_commands()
+  if vim.g.marp_commands_registered then
+    return
   end
-end, { desc = "Install bundled Marp CLI", nargs = "?" })
+  vim.g.marp_commands_registered = true
+
+  vim.api.nvim_create_user_command("MarpStart", M.start, { desc = "Start Marp" })
+  vim.api.nvim_create_user_command("MarpStop", M.stop, { desc = "Stop Marp" })
+  vim.api.nvim_create_user_command("MarpStatus", M.status, { desc = "Show Marp status" })
+  vim.api.nvim_create_user_command("MarpToggle", M.toggle, { desc = "Toggle Marp (start/stop)" })
+
+  if cli.needs_install() then
+    vim.api.nvim_create_user_command("MarpInstall", function(opts)
+      local ok, err = install.sync(opts.args ~= "" and opts.args or nil)
+      if ok then
+        vim.notify("Marp CLI is installed", vim.log.levels.INFO)
+        pcall(vim.api.nvim_del_user_command, "MarpInstall")
+      else
+        vim.notify("Marp install failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
+      end
+    end, { desc = "Install bundled Marp CLI", nargs = "?" })
+  end
+end
+
+function M.setup(options)
+  config.setup(options)
+  register_commands()
+end
+
+register_commands()
 
 return M

--- a/lua/marp/init.lua
+++ b/lua/marp/init.lua
@@ -1,6 +1,7 @@
 local cli = require("marp.cli")
 local config = require("marp/config")
 local install = require("marp.install")
+local lazy = require("marp.lazy")
 local marp = require("marp/marp")
 
 local M = {}
@@ -38,9 +39,11 @@ end
 
 function M.setup(options)
   config.setup(options)
+  vim.g.marp_lazy_opts_applied = true
   register_commands()
 end
 
+lazy.apply()
 register_commands()
 
 return M

--- a/lua/marp/init.lua
+++ b/lua/marp/init.lua
@@ -1,4 +1,5 @@
 local config = require("marp/config")
+local install = require("marp.install")
 local marp = require("marp/marp")
 
 local M = {}
@@ -8,11 +9,20 @@ M.start = marp.start
 M.stop = marp.stop
 M.status = marp.status
 M.toggle = marp.toggle
+M.install = install.sync
 
 -- create MarpStart command
 vim.api.nvim_create_user_command("MarpStart", M.start, { desc = "Start Marp" })
 vim.api.nvim_create_user_command("MarpStop", M.stop, { desc = "Stop Marp" })
 vim.api.nvim_create_user_command("MarpStatus", M.status, { desc = "Show Marp status" })
 vim.api.nvim_create_user_command("MarpToggle", M.toggle, { desc = "Toggle Marp (start/stop)" })
+vim.api.nvim_create_user_command("MarpInstall", function(opts)
+  local ok, err = install.sync(opts.args ~= "" and opts.args or nil)
+  if ok then
+    vim.notify("Marp CLI is installed", vim.log.levels.INFO)
+  else
+    vim.notify("Marp install failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
+  end
+end, { desc = "Install bundled Marp CLI", nargs = "?" })
 
 return M

--- a/lua/marp/install.lua
+++ b/lua/marp/install.lua
@@ -1,0 +1,72 @@
+local util = require("marp.util")
+
+local M = {}
+
+local function plugin_root()
+  local path = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(path, ":h:h:h")
+end
+
+function M.root(plugin_dir)
+  return plugin_dir or plugin_root()
+end
+
+function M.deps_dir(plugin_dir)
+  return M.root(plugin_dir) .. "/deps"
+end
+
+function M.bundled_path(plugin_dir)
+  local bin = M.deps_dir(plugin_dir) .. "/node_modules/.bin/marp"
+  if vim.fn.has("win32") == 1 then
+    bin = bin .. ".cmd"
+  end
+  if vim.fn.filereadable(bin) == 1 or vim.fn.executable(bin) == 1 then
+    return bin
+  end
+  return nil
+end
+
+function M.installed(plugin_dir)
+  return M.bundled_path(plugin_dir) ~= nil
+end
+
+local function run_npm_install(deps_dir, plugin_dir)
+  if vim.fn.executable("npm") ~= 1 then
+    return false, "npm not found; install Node.js v18+ or set marp_command manually"
+  end
+
+  util.log_info("installing Marp CLI into plugin dependencies...")
+
+  local result = vim
+    .system({ "npm", "install", "--no-fund", "--no-audit" }, { cwd = deps_dir, text = true })
+    :wait()
+
+  if result.code ~= 0 then
+    local err = (result.stderr or result.stdout or "npm install failed"):gsub("%s+$", "")
+    return false, err
+  end
+
+  if M.bundled_path(plugin_dir) then
+    util.log_info("Marp CLI installed successfully")
+    return true
+  end
+
+  return false, "npm install finished but marp binary was not found"
+end
+
+function M.sync(plugin_dir)
+  plugin_dir = M.root(plugin_dir)
+  local deps_dir = M.deps_dir(plugin_dir)
+
+  if vim.fn.isdirectory(deps_dir) ~= 1 then
+    return false, "deps directory not found at " .. deps_dir
+  end
+
+  if M.installed(plugin_dir) then
+    return true
+  end
+
+  return run_npm_install(deps_dir, plugin_dir)
+end
+
+return M

--- a/lua/marp/lazy.lua
+++ b/lua/marp/lazy.lua
@@ -1,0 +1,28 @@
+local config = require("marp.config")
+
+local M = {}
+
+--- Apply lazy.nvim `opts` when the plugin spec has no `config` function.
+function M.apply()
+  if vim.g.marp_lazy_opts_applied then
+    return
+  end
+
+  local ok, lazy_config = pcall(require, "lazy.core.config")
+  if not ok then
+    return
+  end
+
+  for _, plugin in pairs(lazy_config.spec.plugins) do
+    local is_marp = plugin.name == "marp-nvim"
+      or (type(plugin.dir) == "string" and plugin.dir:find("marp%-nvim", 1, true))
+
+    if is_marp and type(plugin.opts) == "table" and next(plugin.opts) ~= nil then
+      config.setup(plugin.opts)
+      vim.g.marp_lazy_opts_applied = true
+      return
+    end
+  end
+end
+
+return M

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -7,6 +7,35 @@ local M = {}
 M.jobid = 0
 M._intentional_stop = false
 
+local exit_cleanup_registered = false
+
+local function ensure_exit_cleanup()
+  if exit_cleanup_registered then
+    return
+  end
+  exit_cleanup_registered = true
+
+  vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = vim.api.nvim_create_augroup("MarpExit", { clear = true }),
+    callback = function()
+      M.shutdown()
+    end,
+  })
+end
+
+local function stop_jobs()
+  M._intentional_stop = true
+
+  if config.options.close_browser_on_stop then
+    wrapper.stop()
+  end
+
+  if M.jobid > 0 then
+    pcall(vim.fn.jobstop, M.jobid)
+    M.jobid = 0
+  end
+end
+
 local function on_job_exit(_, exit_code, _)
   M.jobid = 0
 
@@ -87,7 +116,10 @@ function M.start()
     return
   end
 
+  ensure_exit_cleanup()
+
   if not util.wait_for_response("http://localhost:" .. port, wait_for_response_timeout, wait_for_response_delay) then
+    stop_jobs()
     return
   end
 
@@ -119,15 +151,19 @@ function M.stop()
     return
   end
 
-  M._intentional_stop = true
+  stop_jobs()
+  util.log_info("server stopped")
+end
 
-  if config.options.close_browser_on_stop then
-    wrapper.stop()
+--[[
+    Stops Marp silently when Neovim exits.
+]]
+function M.shutdown()
+  if M.jobid == 0 and not wrapper.running() then
+    return
   end
 
-  vim.fn.jobstop(M.jobid)
-  M.jobid = 0
-  util.log_info("server stopped")
+  stop_jobs()
 end
 
 --[[

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -84,7 +84,10 @@ end
 ]]
 function M.start()
   lazy.apply()
-  if not util.dir_contains_md_files(vim.fn.getcwd()) then
+
+  local server_dir = util.resolve_server_dir()
+
+  if not util.can_start_server() then
     util.log_info("no Markdown files found, exiting!")
     return
   end
@@ -98,13 +101,15 @@ function M.start()
   local wait_for_response_timeout = config.options.wait_for_response_timeout
   local wait_for_response_delay = config.options.wait_for_response_delay
 
-  local argv, env, err = cli.server_argv(port, vim.fn.getcwd())
+  local argv, env, err = cli.server_argv(port, server_dir)
   if not argv then
     util.log_error(err or "could not resolve Marp CLI")
     return
   end
 
-  util.log_info("starting server on http://localhost:" .. port)
+  util.log_info(
+    "starting server on http://localhost:" .. port .. " (" .. util.display_server_dir(server_dir) .. ")"
+  )
 
   M.jobid = vim.fn.jobstart(argv, {
     env = env,

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -1,5 +1,6 @@
 local cli = require("marp.cli")
 local config = require("marp/config")
+local lazy = require("marp.lazy")
 local util = require("marp/util")
 local wrapper = require("marp.wrapper")
 
@@ -82,6 +83,7 @@ end
     ```
 ]]
 function M.start()
+  lazy.apply()
   if not util.dir_contains_md_files(vim.fn.getcwd()) then
     util.log_info("no Markdown files found, exiting!")
     return

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -125,12 +125,12 @@ function M.start()
 
   ensure_exit_cleanup()
 
-  if not util.wait_for_response("http://localhost:" .. port, wait_for_response_timeout, wait_for_response_delay) then
+  if not util.wait_for_response(util.local_url(port), wait_for_response_timeout, wait_for_response_delay) then
     stop_jobs()
     return
   end
 
-  local preview_url = "http://localhost:" .. port
+  local preview_url = util.preview_url(port)
 
   if config.options.close_browser_on_stop then
     local ok, err = wrapper.start(port)

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -1,5 +1,6 @@
-local util = require("marp/util")
+local cli = require("marp.cli")
 local config = require("marp/config")
+local util = require("marp/util")
 
 local M = {}
 M.jobid = 0
@@ -47,16 +48,26 @@ function M.start()
   local wait_for_response_timeout = config.options.wait_for_response_timeout
   local wait_for_response_delay = config.options.wait_for_response_delay
 
-  local marp_start_command = "PORT=" .. port .. " marp --server " .. vim.fn.getcwd()
+  local argv, env, err = cli.server_argv(port, vim.fn.getcwd())
+  if not argv then
+    util.log_error(err or "could not resolve Marp CLI")
+    return
+  end
 
   util.log_info("starting server on http://localhost:" .. port)
 
-  M.jobid = vim.fn.jobstart(marp_start_command, {
+  M.jobid = vim.fn.jobstart(argv, {
+    env = env,
     on_exit = function(_, exit_code, _)
       M.jobid = 0
       util.log_info("exit (code=" .. exit_code .. ")")
     end,
   })
+
+  if M.jobid <= 0 then
+    util.log_error("failed to start Marp server")
+    return
+  end
 
   util.wait_for_response("http://localhost:" .. port, wait_for_response_timeout, wait_for_response_delay)
   util.open_url_in_browser("http://localhost:" .. port)

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -1,6 +1,7 @@
 local cli = require("marp.cli")
 local config = require("marp/config")
 local util = require("marp/util")
+local wrapper = require("marp.wrapper")
 
 local M = {}
 M.jobid = 0
@@ -8,6 +9,10 @@ M._intentional_stop = false
 
 local function on_job_exit(_, exit_code, _)
   M.jobid = 0
+
+  if config.options.close_browser_on_stop then
+    wrapper.stop()
+  end
 
   if M._intentional_stop then
     M._intentional_stop = false
@@ -86,7 +91,18 @@ function M.start()
     return
   end
 
-  util.open_url_in_browser("http://localhost:" .. port)
+  local preview_url = "http://localhost:" .. port
+
+  if config.options.close_browser_on_stop then
+    local ok, err = wrapper.start(port)
+    if ok then
+      preview_url = wrapper.preview_url() or preview_url
+    elseif err then
+      util.log_warn(err .. "; opening Marp directly")
+    end
+  end
+
+  util.open_url_in_browser(preview_url)
 end
 
 --[[
@@ -104,6 +120,11 @@ function M.stop()
   end
 
   M._intentional_stop = true
+
+  if config.options.close_browser_on_stop then
+    wrapper.stop()
+  end
+
   vim.fn.jobstop(M.jobid)
   M.jobid = 0
   util.log_info("server stopped")

--- a/lua/marp/marp.lua
+++ b/lua/marp/marp.lua
@@ -4,6 +4,20 @@ local util = require("marp/util")
 
 local M = {}
 M.jobid = 0
+M._intentional_stop = false
+
+local function on_job_exit(_, exit_code, _)
+  M.jobid = 0
+
+  if M._intentional_stop then
+    M._intentional_stop = false
+    return
+  end
+
+  if exit_code ~= 0 then
+    util.log_warn("server exited unexpectedly (code=" .. exit_code .. ")")
+  end
+end
 
 local function marp_running()
   return M.jobid ~= 0
@@ -58,10 +72,9 @@ function M.start()
 
   M.jobid = vim.fn.jobstart(argv, {
     env = env,
-    on_exit = function(_, exit_code, _)
-      M.jobid = 0
-      util.log_info("exit (code=" .. exit_code .. ")")
-    end,
+    stdout_buffered = true,
+    stderr_buffered = true,
+    on_exit = on_job_exit,
   })
 
   if M.jobid <= 0 then
@@ -69,7 +82,10 @@ function M.start()
     return
   end
 
-  util.wait_for_response("http://localhost:" .. port, wait_for_response_timeout, wait_for_response_delay)
+  if not util.wait_for_response("http://localhost:" .. port, wait_for_response_timeout, wait_for_response_delay) then
+    return
+  end
+
   util.open_url_in_browser("http://localhost:" .. port)
 end
 
@@ -82,6 +98,12 @@ end
     ```
 ]]
 function M.stop()
+  if M.jobid == 0 then
+    util.log_info("not running")
+    return
+  end
+
+  M._intentional_stop = true
   vim.fn.jobstop(M.jobid)
   M.jobid = 0
   util.log_info("server stopped")

--- a/lua/marp/util.lua
+++ b/lua/marp/util.lua
@@ -83,6 +83,66 @@ function M.wait_for_response(url, max_attempts, delay_between_attempts)
 end
 
 --[[]
+    Resolves the directory to pass to `marp --server`.
+    Prefers the current Markdown buffer's directory over cwd so large projects
+    (e.g. Rails repos) are not served from the repository root.
+]]
+function M.resolve_server_dir()
+  local opts = require("marp.config").options
+
+  if opts.server_dir then
+    return vim.fn.fnamemodify(opts.server_dir, ":p")
+  end
+
+  if opts.use_buffer_dir then
+    local bufname = vim.api.nvim_buf_get_name(0)
+    if bufname ~= "" and vim.bo.filetype == "markdown" then
+      local dir = vim.fn.fnamemodify(bufname, ":p:h")
+      if vim.fn.isdirectory(dir) == 1 then
+        return dir
+      end
+    end
+  end
+
+  return vim.fn.getcwd()
+end
+
+function M.can_start_server()
+  local bufname = vim.api.nvim_buf_get_name(0)
+  if bufname ~= "" and vim.bo.filetype == "markdown" and vim.fn.filereadable(bufname) == 1 then
+    return true
+  end
+
+  return M.dir_contains_md_files(M.resolve_server_dir())
+end
+
+--- Path relative to cwd for display (e.g. `/slides` instead of the full absolute path).
+function M.display_server_dir(server_dir)
+  local abs_cwd = vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
+  local abs_dir = vim.fn.fnamemodify(server_dir, ":p")
+
+  if abs_dir == abs_cwd then
+    return "/."
+  end
+
+  if vim.fs and vim.fs.relpath then
+    local rel, err = vim.fs.relpath(abs_dir, abs_cwd)
+    if rel and not err and not rel:match("^%.%.") then
+      return "/" .. rel
+    end
+  end
+
+  if abs_dir:sub(1, #abs_cwd) == abs_cwd then
+    local suffix = abs_dir:sub(#abs_cwd + 1):gsub("^/", "")
+    if suffix ~= "" then
+      return "/" .. suffix
+    end
+  end
+
+  return "/" .. vim.fn.fnamemodify(abs_dir, ":t")
+end
+
+--[[]
     Determines whether a directory contains Markdown files.
     @param current_dir (string) The directory to check.
     @return (boolean) Whether the directory contains Markdown files.

--- a/lua/marp/util.lua
+++ b/lua/marp/util.lua
@@ -10,22 +10,20 @@ local M = {}
     ```
 ]]
 function M.open_url_in_browser(url)
-  -- Construct the shell command to open the URL in a browser based on the OS
-  local open_cmd = nil
-  if vim.fn.has("mac") == 1 then
-    open_cmd = "open"
-  elseif vim.fn.has("unix") == 1 then
-    open_cmd = "xdg-open"
-  elseif vim.fn.has("win32") == 1 then
-    open_cmd = "start"
-  else
-    error("Unsupported operating system")
+  if vim.ui and vim.ui.open then
+    vim.ui.open(url)
     return
   end
 
-  -- Execute the shell command to open the URL in a browser
-  local cmd = string.format("%s %s", open_cmd, url)
-  vim.api.nvim_command("! " .. cmd)
+  if vim.fn.has("mac") == 1 then
+    vim.fn.jobstart({ "open", url }, { detach = true })
+  elseif vim.fn.has("unix") == 1 then
+    vim.fn.jobstart({ "xdg-open", url }, { detach = true })
+  elseif vim.fn.has("win32") == 1 then
+    vim.fn.jobstart({ "cmd", "/c", "start", "", url }, { detach = true })
+  else
+    M.log_error("unsupported operating system")
+  end
 end
 
 --[[
@@ -58,26 +56,30 @@ end
     ```
 ]]
 function M.wait_for_response(url, max_attempts, delay_between_attempts)
-  local attempts = 0
-  local server_responded = false
+  local null_device = vim.fn.has("win32") == 1 and "NUL" or "/dev/null"
 
-  while attempts < max_attempts and not server_responded do
-    local success = false
-    local response = vim.fn.systemlist('curl -s -o /dev/null -w "%{http_code}" ' .. url)
+  for attempt = 1, max_attempts do
+    local result = vim.system({
+      "curl",
+      "-s",
+      "-o",
+      null_device,
+      "-w",
+      "%{http_code}",
+      url,
+    }, { text = true }):wait()
 
-    if response[1] == "200" then
-      success = true
+    if result.stdout == "200" then
+      return true
     end
 
-    if success then
-      print("Server responded successfully!")
-      server_responded = true
-    else
-      attempts = attempts + 1
-      print("Attempt", attempts, "- Server not yet responding. Retrying in", delay_between_attempts, "second(s)...")
-      M.wait(1)
+    if attempt < max_attempts then
+      M.wait(delay_between_attempts)
     end
   end
+
+  M.log_warn("server did not respond in time")
+  return false
 end
 
 --[[]

--- a/lua/marp/util.lua
+++ b/lua/marp/util.lua
@@ -118,8 +118,15 @@ end
 
 --- Path relative to cwd for display (e.g. `/slides` instead of the full absolute path).
 function M.display_server_dir(server_dir)
-  local abs_cwd = vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
-  local abs_dir = vim.fn.fnamemodify(server_dir, ":p")
+  local function strip_slash(path)
+    if path:sub(-1) == "/" then
+      return path:sub(1, -2)
+    end
+    return path
+  end
+
+  local abs_cwd = strip_slash(vim.fn.fnamemodify(vim.fn.getcwd(), ":p"))
+  local abs_dir = strip_slash(vim.fn.fnamemodify(server_dir, ":p"))
 
   if abs_dir == abs_cwd then
     return "/."
@@ -128,7 +135,10 @@ function M.display_server_dir(server_dir)
   if vim.fs and vim.fs.relpath then
     local rel, err = vim.fs.relpath(abs_dir, abs_cwd)
     if rel and not err and not rel:match("^%.%.") then
-      return "/" .. rel
+      rel = strip_slash(rel)
+      if rel ~= "" then
+        return "/" .. rel
+      end
     end
   end
 

--- a/lua/marp/util.lua
+++ b/lua/marp/util.lua
@@ -1,5 +1,65 @@
 local M = {}
 
+--- Whether Neovim is running inside WSL (Windows browser is opened via wslview).
+function M.is_wsl()
+  if vim.fn.has("wsl") == 1 then
+    return true
+  end
+
+  local version_file = io.open("/proc/version", "r")
+  if not version_file then
+    return false
+  end
+
+  local version = version_file:read("*a") or ""
+  version_file:close()
+  return version:lower():match("microsoft") ~= nil
+end
+
+--- First IPv4 address of the WSL instance (reachable from the Windows host).
+function M.wsl_ip()
+  local result = vim.system({ "hostname", "-I" }, { text = true }):wait()
+  if result.code ~= 0 or not result.stdout then
+    return nil
+  end
+
+  return result.stdout:match("%S+")
+end
+
+--- Hostname used in preview URLs opened in the browser.
+function M.preview_host()
+  local opts = require("marp.config").options
+  if opts.preview_host and opts.preview_host ~= "" then
+    return opts.preview_host
+  end
+
+  if M.is_wsl() then
+    return M.wsl_ip() or "127.0.0.1"
+  end
+
+  return "127.0.0.1"
+end
+
+--- Host the preview wrapper listens on (0.0.0.0 on WSL so Windows can connect).
+function M.wrapper_bind_host()
+  if M.is_wsl() then
+    return "0.0.0.0"
+  end
+
+  return "127.0.0.1"
+end
+
+--- Build a browser-facing preview URL for the given port.
+function M.preview_url(port)
+  return "http://" .. M.preview_host() .. ":" .. port .. "/"
+end
+
+--- Local URL for health checks from inside Neovim's environment.
+function M.local_url(port, path)
+  path = path or "/"
+  return "http://127.0.0.1:" .. port .. path
+end
+
 --[[
     Opens a URL in a browser.
     @param url (string) The URL to open.

--- a/lua/marp/wrapper.lua
+++ b/lua/marp/wrapper.lua
@@ -78,29 +78,30 @@ function M.start(marp_port)
   return true
 end
 
-function M.close_browser()
+function M.stop()
   if not M.wrapper_port then
     return
   end
+
+  local wrapper_port = M.wrapper_port
+  local wrapper_jobid = M.jobid
 
   vim.system({
     "curl",
     "-s",
     "-X",
     "POST",
-    "http://127.0.0.1:" .. M.wrapper_port .. "/close",
+    "http://127.0.0.1:" .. wrapper_port .. "/close",
   }, { text = true }):wait()
-end
-
-function M.stop()
-  M.close_browser()
-
-  if M.jobid > 0 then
-    vim.fn.jobstop(M.jobid)
-    M.jobid = 0
-  end
 
   M.wrapper_port = nil
+  M.jobid = 0
+
+  if wrapper_jobid > 0 then
+    vim.defer_fn(function()
+      pcall(vim.fn.jobstop, wrapper_jobid)
+    end, 200)
+  end
 end
 
 return M

--- a/lua/marp/wrapper.lua
+++ b/lua/marp/wrapper.lua
@@ -26,7 +26,7 @@ function M.preview_url()
   if not M.wrapper_port then
     return nil
   end
-  return "http://127.0.0.1:" .. M.wrapper_port .. "/"
+  return util.preview_url(M.wrapper_port)
 end
 
 function M.running()
@@ -55,6 +55,8 @@ function M.start(marp_port)
     script,
     tostring(marp_port),
     tostring(wrapper_port),
+    util.preview_host(),
+    util.wrapper_bind_host(),
   }, {
     stdout_buffered = true,
     stderr_buffered = true,
@@ -69,8 +71,7 @@ function M.start(marp_port)
     return false, "failed to start preview wrapper"
   end
 
-  local url = M.preview_url()
-  if not util.wait_for_response(url, 10, 0.2) then
+  if not util.wait_for_response(util.local_url(wrapper_port), 10, 0.2) then
     M.stop()
     return false, "preview wrapper did not become ready"
   end
@@ -91,7 +92,7 @@ function M.stop()
     "-s",
     "-X",
     "POST",
-    "http://127.0.0.1:" .. wrapper_port .. "/close",
+    util.local_url(wrapper_port, "/close"),
   }, { text = true }):wait()
 
   M.wrapper_port = nil

--- a/lua/marp/wrapper.lua
+++ b/lua/marp/wrapper.lua
@@ -1,0 +1,106 @@
+local util = require("marp.util")
+
+local M = {}
+
+M.jobid = 0
+M.wrapper_port = nil
+
+local function plugin_root()
+  local path = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(path, ":h:h:h")
+end
+
+function M.script_path()
+  return plugin_root() .. "/wrapper/server.js"
+end
+
+function M.port_for(marp_port)
+  local opts = require("marp.config").options
+  if opts.wrapper_port then
+    return opts.wrapper_port
+  end
+  return marp_port + 1
+end
+
+function M.preview_url()
+  if not M.wrapper_port then
+    return nil
+  end
+  return "http://127.0.0.1:" .. M.wrapper_port .. "/"
+end
+
+function M.running()
+  return M.jobid > 0 and M.wrapper_port ~= nil
+end
+
+function M.start(marp_port)
+  if M.running() then
+    return true
+  end
+
+  if vim.fn.executable("node") ~= 1 then
+    return false, "node is required for the preview wrapper"
+  end
+
+  local script = M.script_path()
+  if vim.fn.filereadable(script) ~= 1 then
+    return false, "preview wrapper not found at " .. script
+  end
+
+  local wrapper_port = M.port_for(marp_port)
+  M.wrapper_port = wrapper_port
+
+  M.jobid = vim.fn.jobstart({
+    "node",
+    script,
+    tostring(marp_port),
+    tostring(wrapper_port),
+  }, {
+    stdout_buffered = true,
+    stderr_buffered = true,
+    on_exit = function()
+      M.jobid = 0
+      M.wrapper_port = nil
+    end,
+  })
+
+  if M.jobid <= 0 then
+    M.wrapper_port = nil
+    return false, "failed to start preview wrapper"
+  end
+
+  local url = M.preview_url()
+  if not util.wait_for_response(url, 10, 0.2) then
+    M.stop()
+    return false, "preview wrapper did not become ready"
+  end
+
+  return true
+end
+
+function M.close_browser()
+  if not M.wrapper_port then
+    return
+  end
+
+  vim.system({
+    "curl",
+    "-s",
+    "-X",
+    "POST",
+    "http://127.0.0.1:" .. M.wrapper_port .. "/close",
+  }, { text = true }):wait()
+end
+
+function M.stop()
+  M.close_browser()
+
+  if M.jobid > 0 then
+    vim.fn.jobstop(M.jobid)
+    M.jobid = 0
+  end
+
+  M.wrapper_port = nil
+end
+
+return M

--- a/plugin/marp.lua
+++ b/plugin/marp.lua
@@ -1,0 +1,16 @@
+local group = vim.api.nvim_create_augroup("Marp", { clear = true })
+
+local function load()
+  require("marp")
+end
+
+vim.api.nvim_create_autocmd("FileType", {
+  group = group,
+  pattern = "markdown",
+  callback = load,
+})
+
+-- Plugin may be added to rtp after the first FileType event (e.g. lazy.nvim).
+if vim.bo.filetype == "markdown" then
+  load()
+end

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,0 +1,24 @@
+local root = vim.fn.fnamemodify(vim.fn.expand("<sfile>"), ":p:h:h")
+vim.opt.rtp:prepend(root)
+
+local plenary_path = os.getenv("PLENARY_PATH")
+if not plenary_path or plenary_path == "" then
+  plenary_path = root .. "/.deps/plenary.nvim"
+  if vim.fn.isdirectory(plenary_path) == 0 then
+    vim.fn.mkdir(root .. "/.deps", "p")
+    local job = vim.fn.jobstart({
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://github.com/nvim-lua/plenary.nvim",
+      plenary_path,
+    })
+    local result = vim.fn.jobwait({ job }, 120000)
+    if result[1] ~= 0 then
+      error("failed to clone plenary.nvim into " .. plenary_path)
+    end
+  end
+end
+
+vim.opt.rtp:prepend(plenary_path)

--- a/spec/cli_spec.lua
+++ b/spec/cli_spec.lua
@@ -1,0 +1,40 @@
+local config = require("marp.config")
+local cli = require("marp.cli")
+
+describe("marp.cli", function()
+  before_each(function()
+    config.setup()
+  end)
+
+  describe("resolve_argv", function()
+    it("uses marp_command when set", function()
+      config.setup({ marp_command = "/custom/marp", auto_install = false, use_npx_fallback = false })
+
+      local argv, err = cli.resolve_argv()
+
+      assert.is_nil(err)
+      assert.same({ "/custom/marp" }, argv)
+    end)
+
+    it("splits marp_command on whitespace", function()
+      config.setup({ marp_command = "npx @marp-team/marp-cli", auto_install = false, use_npx_fallback = false })
+
+      local argv, err = cli.resolve_argv()
+
+      assert.is_nil(err)
+      assert.same({ "npx", "@marp-team/marp-cli" }, argv)
+    end)
+  end)
+
+  describe("server_argv", function()
+    it("builds server argv and PORT env from marp_command", function()
+      config.setup({ marp_command = "/custom/marp", auto_install = false, use_npx_fallback = false })
+
+      local argv, env, err = cli.server_argv(9090, "/tmp/slides")
+
+      assert.is_nil(err)
+      assert.same({ "/custom/marp", "--server", "/tmp/slides" }, argv)
+      assert.equals("9090", env.PORT)
+    end)
+  end)
+end)

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -1,0 +1,46 @@
+local config = require("marp.config")
+
+describe("marp.config", function()
+  before_each(function()
+    package.loaded["marp.config"] = nil
+    config = require("marp.config")
+  end)
+
+  it("applies defaults on load", function()
+    assert.equals(8080, config.options.port)
+    assert.equals(30, config.options.wait_for_response_timeout)
+    assert.equals(1, config.options.wait_for_response_delay)
+    assert.is_nil(config.options.marp_command)
+    assert.is_true(config.options.auto_install)
+    assert.is_true(config.options.use_npx_fallback)
+    assert.equals("latest", config.options.marp_version)
+    assert.is_false(config.options.close_browser_on_stop)
+    assert.is_nil(config.options.wrapper_port)
+    assert.is_nil(config.options.server_dir)
+    assert.is_true(config.options.use_buffer_dir)
+  end)
+
+  it("merges user options without mutating defaults", function()
+    config.setup({
+      port = 9000,
+      close_browser_on_stop = true,
+    })
+
+    assert.equals(9000, config.options.port)
+    assert.is_true(config.options.close_browser_on_stop)
+    assert.equals(30, config.options.wait_for_response_timeout)
+
+    config.setup()
+    assert.equals(8080, config.options.port)
+    assert.is_false(config.options.close_browser_on_stop)
+  end)
+
+  it("replaces the full options table on each setup", function()
+    config.setup({ use_buffer_dir = false })
+    assert.is_false(config.options.use_buffer_dir)
+
+    config.setup({ server_dir = "/tmp/slides" })
+    assert.equals("/tmp/slides", config.options.server_dir)
+    assert.is_true(config.options.use_buffer_dir)
+  end)
+end)

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -148,4 +148,23 @@ describe("marp.util", function()
       assert.is_false(util.can_start_server())
     end)
   end)
+
+  describe("preview_host", function()
+    it("uses preview_host from config when set", function()
+      config.setup({ preview_host = "192.168.1.10" })
+
+      assert.equals("192.168.1.10", util.preview_host())
+    end)
+
+    it("builds preview URLs with the configured host", function()
+      config.setup({ preview_host = "192.168.1.10" })
+
+      assert.equals("http://192.168.1.10:8081/", util.preview_url(8081))
+    end)
+
+    it("builds local health-check URLs on 127.0.0.1", function()
+      assert.equals("http://127.0.0.1:8080/", util.local_url(8080))
+      assert.equals("http://127.0.0.1:8081/close", util.local_url(8081, "/close"))
+    end)
+  end)
 end)

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -1,0 +1,151 @@
+local config = require("marp.config")
+local util = require("marp.util")
+
+local function norm(path)
+  local resolved = path
+  if vim.fs and vim.fs.realpath then
+    local ok, real = pcall(vim.fs.realpath, path)
+    if ok and real then
+      resolved = real
+    end
+  end
+  resolved = vim.fn.fnamemodify(resolved, ":p")
+  if resolved:sub(-1) == "/" then
+    resolved = resolved:sub(1, -2)
+  end
+  return resolved
+end
+
+describe("marp.util", function()
+  local root
+  local original_cwd
+
+  before_each(function()
+    config.setup()
+    original_cwd = vim.fn.getcwd()
+    root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+    vim.cmd("cd " .. vim.fn.fnameescape(root))
+  end)
+
+  after_each(function()
+    vim.cmd("cd " .. vim.fn.fnameescape(original_cwd))
+    pcall(vim.fn.delete, root, "rf")
+  end)
+
+  local function write_markdown(path, name)
+    local file = path .. "/" .. name
+    local f = io.open(file, "w")
+    f:write("# slide\n")
+    f:close()
+    return file
+  end
+
+  local function open_markdown_buffer(file)
+    vim.cmd("edit " .. vim.fn.fnameescape(file))
+    vim.bo.filetype = "markdown"
+  end
+
+  describe("resolve_server_dir", function()
+    it("uses server_dir when set", function()
+      local slides = root .. "/slides"
+      vim.fn.mkdir(slides, "p")
+
+      config.setup({ server_dir = slides })
+
+      assert.equals(norm(slides), norm(util.resolve_server_dir()))
+    end)
+
+    it("uses the markdown buffer directory when use_buffer_dir is true", function()
+      local slides = vim.fn.getcwd() .. "/slides"
+      vim.fn.mkdir(slides, "p")
+      local file = write_markdown(slides, "deck.md")
+
+      open_markdown_buffer(file)
+
+      assert.equals(norm(slides), norm(util.resolve_server_dir()))
+    end)
+
+    it("falls back to cwd when use_buffer_dir is false", function()
+      local slides = vim.fn.getcwd() .. "/slides"
+      vim.fn.mkdir(slides, "p")
+      local file = write_markdown(slides, "deck.md")
+
+      config.setup({ use_buffer_dir = false })
+      open_markdown_buffer(file)
+
+      assert.equals(norm(vim.fn.getcwd()), norm(util.resolve_server_dir()))
+    end)
+
+    it("falls back to cwd when the buffer is not markdown", function()
+      local slides = vim.fn.getcwd() .. "/slides"
+      vim.fn.mkdir(slides, "p")
+      local file = write_markdown(slides, "deck.md")
+
+      vim.cmd("edit " .. vim.fn.fnameescape(file))
+      vim.bo.filetype = "text"
+
+      assert.equals(norm(vim.fn.getcwd()), norm(util.resolve_server_dir()))
+    end)
+  end)
+
+  describe("display_server_dir", function()
+    it("shows / when server_dir is cwd", function()
+      assert.equals("/.", util.display_server_dir(vim.fn.getcwd()))
+    end)
+
+    it("shows a relative path for a subdirectory of cwd", function()
+      local slides = vim.fn.getcwd() .. "/slides"
+      vim.fn.mkdir(slides, "p")
+
+      assert.equals("/slides", util.display_server_dir(slides))
+    end)
+
+    it("shows the directory name when outside cwd", function()
+      local outside = "/tmp/marp-nvim-spec-outside"
+      vim.fn.mkdir(outside, "p")
+
+      assert.equals("/marp-nvim-spec-outside", util.display_server_dir(outside))
+
+      vim.fn.delete(outside, "rf")
+    end)
+  end)
+
+  describe("dir_contains_md_files", function()
+    it("returns true when a markdown file exists", function()
+      write_markdown(root, "deck.md")
+
+      assert.is_true(util.dir_contains_md_files(root))
+    end)
+
+    it("returns false when no markdown files exist", function()
+      local f = io.open(root .. "/readme.txt", "w")
+      f:write("nope\n")
+      f:close()
+
+      assert.is_false(util.dir_contains_md_files(root))
+    end)
+  end)
+
+  describe("can_start_server", function()
+    it("returns true for a readable markdown buffer", function()
+      local file = write_markdown(root, "deck.md")
+      open_markdown_buffer(file)
+
+      assert.is_true(util.can_start_server())
+    end)
+
+    it("returns true when the resolved directory contains markdown", function()
+      write_markdown(root, "deck.md")
+      vim.cmd("enew")
+
+      assert.is_true(util.can_start_server())
+    end)
+
+    it("returns false when there is no markdown buffer or directory content", function()
+      vim.cmd("enew")
+
+      assert.is_false(util.can_start_server())
+    end)
+  end)
+end)

--- a/wrapper/server.js
+++ b/wrapper/server.js
@@ -5,9 +5,11 @@ const http = require("http");
 
 const marpPort = Number(process.argv[2]);
 const wrapperPort = Number(process.argv[3]);
+const marpHost = process.argv[4] || "127.0.0.1";
+const bindHost = process.argv[5] || "127.0.0.1";
 
 if (!marpPort || !wrapperPort) {
-  console.error("usage: node server.js <marp-port> <wrapper-port>");
+  console.error("usage: node server.js <marp-port> <wrapper-port> [marp-host] [bind-host]");
   process.exit(1);
 }
 
@@ -15,7 +17,7 @@ if (!marpPort || !wrapperPort) {
 let clients = [];
 
 function previewHtml() {
-  const marpUrl = `http://127.0.0.1:${marpPort}/`;
+  const marpUrl = `http://${marpHost}:${marpPort}/`;
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -92,7 +94,7 @@ const server = http.createServer((req, res) => {
   res.end("not found");
 });
 
-server.listen(wrapperPort, "127.0.0.1", () => {
+server.listen(wrapperPort, bindHost, () => {
   process.stdout.write(`ready:${wrapperPort}\n`);
 });
 

--- a/wrapper/server.js
+++ b/wrapper/server.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+"use strict";
+
+const http = require("http");
+
+const marpPort = Number(process.argv[2]);
+const wrapperPort = Number(process.argv[3]);
+
+if (!marpPort || !wrapperPort) {
+  console.error("usage: node server.js <marp-port> <wrapper-port>");
+  process.exit(1);
+}
+
+/** @type {import("http").ServerResponse[]} */
+let clients = [];
+
+function previewHtml() {
+  const marpUrl = `http://127.0.0.1:${marpPort}/`;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Marp Preview</title>
+  <style>
+    html, body { margin: 0; height: 100%; overflow: hidden; background: #111; }
+    iframe { width: 100%; height: 100%; border: 0; }
+  </style>
+</head>
+<body>
+  <iframe src="${marpUrl}" title="Marp preview"></iframe>
+  <script>
+    const source = new EventSource("/events");
+    source.addEventListener("close", function () {
+      source.close();
+      window.close();
+    });
+    source.onerror = function () {
+      source.close();
+    };
+  </script>
+</body>
+</html>`;
+}
+
+function writeEvent(res, event, data) {
+  res.write(`event: ${event}\ndata: ${data || ""}\n\n`);
+}
+
+function notifyClose() {
+  for (const client of clients) {
+    try {
+      writeEvent(client, "close", "{}");
+      client.end();
+    } catch (_) {
+      // client may already be gone
+    }
+  }
+  clients = [];
+}
+
+const server = http.createServer((req, res) => {
+  const path = (req.url || "").split("?")[0];
+
+  if (req.method === "GET" && path === "/") {
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(previewHtml());
+    return;
+  }
+
+  if (req.method === "GET" && path === "/events") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    res.write(": connected\n\n");
+    clients.push(res);
+    req.on("close", () => {
+      clients = clients.filter((client) => client !== res);
+    });
+    return;
+  }
+
+  if (req.method === "POST" && path === "/close") {
+    notifyClose();
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain" });
+  res.end("not found");
+});
+
+server.listen(wrapperPort, "127.0.0.1", () => {
+  process.stdout.write(`ready:${wrapperPort}\n`);
+});
+
+function shutdown() {
+  notifyClose();
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);


### PR DESCRIPTION
## Summary
- Detect when Neovim is running inside WSL and use the VM IP for browser preview URLs instead of `127.0.0.1`
- Bind the preview wrapper to `0.0.0.0` on WSL so the Windows browser (opened via `wslview`) can reach it
- Point the wrapper iframe at the same host so Marp on port 8080 loads correctly
- Add optional `preview_host` config for manual override when auto-detection fails

## Test plan
- [ ] On WSL, run `:MarpStart` with a Markdown buffer open and confirm the browser opens using the WSL IP (e.g. `http://172.x.x.x:8080/` or `:8081/` with `close_browser_on_stop`)
- [ ] Confirm the preview loads without "connection refused"
- [ ] On macOS/Linux (non-WSL), confirm preview still opens on `127.0.0.1` as before
- [ ] Run `make test` and confirm specs pass


Made with [Cursor](https://cursor.com)